### PR TITLE
Updated question schema

### DIFF
--- a/app/components/App.vue
+++ b/app/components/App.vue
@@ -78,9 +78,10 @@ export default {
 
                 if(snippet.task_text) {
                     const task = snippet.task_text;
-                    const trimmedUserAnswer = userAnswer.trim();
+                    const trimmedUserAnswer = userAnswer ? userAnswer.trim() : "";
                     task.user_answer = trimmedUserAnswer;
-                    task.user_correct = task.correct_answers.indexOf(trimmedUserAnswer) > -1;
+                    task.user_correct =
+                        task.correct_answers.indexOf(trimmedUserAnswer) > -1;
                     totalTasks ++;
                     correctTasks += task.user_correct ? 1 : 0;
                 } else if(snippet.task_number) {

--- a/app/components/App.vue
+++ b/app/components/App.vue
@@ -78,8 +78,9 @@ export default {
 
                 if(snippet.task_text) {
                     const task = snippet.task_text;
-                    task.user_answer = userAnswer;
-                    task.user_correct = userAnswer == task.correct_answer;
+                    const trimmedUserAnswer = userAnswer.trim();
+                    task.user_answer = trimmedUserAnswer;
+                    task.user_correct = task.correct_answers.indexOf(trimmedUserAnswer) > -1;
                     totalTasks ++;
                     correctTasks += task.user_correct ? 1 : 0;
                 } else if(snippet.task_number) {

--- a/app/components/App.vue
+++ b/app/components/App.vue
@@ -81,7 +81,9 @@ export default {
                     const trimmedUserAnswer = userAnswer ? userAnswer.trim() : "";
                     task.user_answer = trimmedUserAnswer;
                     task.user_correct =
-                        task.correct_answers.indexOf(trimmedUserAnswer) > -1;
+                        task.correct_answers
+                        .map((answer) => answer.toLowerCase())
+                        .indexOf(trimmedUserAnswer.toLowerCase()) > -1;
                     totalTasks ++;
                     correctTasks += task.user_correct ? 1 : 0;
                 } else if(snippet.task_number) {

--- a/app/components/ResultSnippet.vue
+++ b/app/components/ResultSnippet.vue
@@ -3,6 +3,9 @@
     <div v-if="snippet.text" class="form-group mt-10">
         <label class="form-label"><fl-text :value="snippet.text" /></label>
     </div>
+    <div v-if="snippet.afterword" class="form-group mt-10">
+        <label class="form-label"><fl-text :value="snippet.afterword" /></label>
+    </div>
     <h4 v-if="snippet.header1">
         <fl-text :value="snippet.header1" />
     </h4>

--- a/app/components/ResultSnippet.vue
+++ b/app/components/ResultSnippet.vue
@@ -4,7 +4,7 @@
         <label class="form-label"><fl-text :value="snippet.text" /></label>
     </div>
     <div v-if="snippet.afterword" class="form-group mt-10">
-        <label class="form-label"><fl-text :value="snippet.afterword" /></label>
+        <div class="toast toast-primary"><fl-text :value="snippet.afterword" /></div>
     </div>
     <h4 v-if="snippet.header1">
         <fl-text :value="snippet.header1" />

--- a/app/components/ResultTextAnswer.vue
+++ b/app/components/ResultTextAnswer.vue
@@ -5,7 +5,7 @@
     </span>
     <input readonly :value="snippet.user_answer" class="form-input"
         :style="style"/>
-    <input readonly :value="snippet.correct_answer" class="form-input"
+    <input readonly :value="snippet.correct_answers[0]" class="form-input"
         v-if="!snippet.user_correct" />
     <span v-if="snippet.after" class="input-group-addon">
         <fl-text :value="snippet.after" />

--- a/app/components/ResultTextAnswer.vue
+++ b/app/components/ResultTextAnswer.vue
@@ -5,7 +5,7 @@
     </span>
     <input readonly :value="snippet.user_answer" class="form-input"
         :style="style"/>
-    <input readonly :value="snippet.correct_answers[0]" class="form-input"
+    <input readonly :value="answer" class="form-input"
         v-if="!snippet.user_correct" />
     <span v-if="snippet.after" class="input-group-addon">
         <fl-text :value="snippet.after" />
@@ -26,6 +26,10 @@ export default {
                 "background-color": this.snippet.user_correct ?
                     "#8A97F9" : "#FFA500"
             };
+        },
+        answer: function() {
+            return this.snippet.correct_answer ?
+                this.snippet.correct_answer : this.snippet.correct_answers[0];
         }
     },
     components: {

--- a/example-quiz/q_math.yaml
+++ b/example-quiz/q_math.yaml
@@ -23,6 +23,10 @@ content:
 - task_text:
     correct_answers: [Ramanujan]
     max_len: 20
+- afterword: >
+    Srinivasa Ramanujan (22 December 1887 – 26 April 1920) was an Indian mathematician
+    renown for his contributions to mathematical analysis, number theory,
+    infinite series and continued fractions.
 - separator
 - text: "Compute the following matrix product:"
 - text: >

--- a/example-quiz/q_math.yaml
+++ b/example-quiz/q_math.yaml
@@ -21,7 +21,7 @@ content:
     \frac{(4k)!(1103+26390k)}{(k!)^{4} 396^{4k}}
     $
 - task_text:
-    correct_answer: Ramanujan
+    correct_answers: [Ramanujan]
     max_len: 20
 - separator
 - text: "Compute the following matrix product:"

--- a/spec/schema_static.yaml
+++ b/spec/schema_static.yaml
@@ -67,6 +67,6 @@ task_chunk_text:
     task_text: include("answers_text")
 answers_text:
     before: str(required=False) # maybe it should be required
-    correct_answers: list(str(), min=1)
+    correct_answers: list(str(), min=1) # the first element will be displayed as the correct one
     max_len: num(min=1) # max. length of the text input, at least 1 char
     after: str(required=False) # e.g. for units

--- a/spec/schema_static.yaml
+++ b/spec/schema_static.yaml
@@ -8,6 +8,7 @@ content: >-
         include("header3_chunk"),
         include("text_chunk"),
         include("hint_chunk"),
+        include("afterword_chunk"),
         include("image_chunk"),
         include("task_chunk_mc_one_correct"),
         include("task_chunk_mc_multiple_correct"),
@@ -31,6 +32,9 @@ text_chunk:
 
 hint_chunk:
     hint: str()
+
+afterword_chunk:
+    afterword: str()
 
 image_chunk:
     image: str()
@@ -56,13 +60,13 @@ answers_number:
     before: str(required=False) # maybe it should be required
     correct_answer: num()
     abs_tol: num(min=0) # tolerance must be non-negative
-    after: str(required=False) # just in case, e.g. for units
+    after: str(required=False) # e.g. for units
 
 # Task: Enter text
 task_chunk_text:
     task_text: include("answers_text")
 answers_text:
     before: str(required=False) # maybe it should be required
-    correct_answer: str()
+    correct_answers: list(str(), min=1)
     max_len: num(min=1) # max. length of the text input, at least 1 char
-    after: str(required=False) # just in case, e.g. for units
+    after: str(required=False) # e.g. for units


### PR DESCRIPTION
See #8

- [x] Multiple correct answers in `task_text` -> @mp4096
- [x] Implement text chunks that are shown only on the results screen -> @mp4096 
- [x] Case insensitive comparison for `task_text` -> @syxolk Can we convert the correct answers to lowercase server-side? Probably in `prerender.js`.

:dolphin: 